### PR TITLE
Issue #4 - Melhorar tratamento de exceções

### DIFF
--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/ApiExceptionHandler.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/ApiExceptionHandler.java
@@ -1,0 +1,77 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception;
+
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.log.ErrorLogger;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.log.WarnLogger;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.ResponseError;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.TypeError;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.ValidationError;
+import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiExceptionHandler.class);
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseError> handleValidationException(MethodArgumentNotValidException exception, WebRequest request) {
+        String path = getPathFromRequest(request);
+        List<ValidationError> validationErrors = exception.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> new ValidationError(fieldError.getField(), fieldError.getDefaultMessage()))
+                .collect(Collectors.toList());
+        WarnLogger.log(TypeError.BAD_REQUEST, path, exception);
+        ResponseError responseError = new ResponseError(TypeError.BAD_REQUEST, path, validationErrors);
+        return new ResponseEntity<>(responseError, TypeError.BAD_REQUEST.getHttpStatus());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ResponseError> handleEntityNotFoundException(
+            EntityNotFoundException exception, WebRequest request
+    ) {
+        String path = getPathFromRequest(request);
+        WarnLogger.log(TypeError.NOT_FOUND, path, exception);
+        ResponseError responseError = new ResponseError(TypeError.NOT_FOUND, path);
+        return new ResponseEntity<>(responseError, TypeError.NOT_FOUND.getHttpStatus());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ResponseError> handleDataIntegrityViolation(
+            DataIntegrityViolationException exception, WebRequest request
+    ) {
+        String path = getPathFromRequest(request);
+        WarnLogger.log(TypeError.BAD_REQUEST, path, exception);
+        ResponseError responseError = new ResponseError(TypeError.BAD_REQUEST, path);
+        return new ResponseEntity<>(responseError, TypeError.BAD_REQUEST.getHttpStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseError> handleGenericException(Exception exception, WebRequest request) {
+        String path = getPathFromRequest(request);
+        ErrorLogger.log(TypeError.INTERNAL_SERVER_ERROR, path, exception);
+        ResponseError responseError = new ResponseError(TypeError.INTERNAL_SERVER_ERROR, path);
+        return new ResponseEntity<>(responseError, TypeError.INTERNAL_SERVER_ERROR.getHttpStatus());
+    }
+
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<ResponseError> handleThrowable(Throwable throwable, WebRequest request) {
+        String path = getPathFromRequest(request);
+        ErrorLogger.log(TypeError.INTERNAL_SERVER_ERROR, path, throwable);
+        ResponseError responseError = new ResponseError(TypeError.INTERNAL_SERVER_ERROR, path);
+        return new ResponseEntity<>(responseError, TypeError.INTERNAL_SERVER_ERROR.getHttpStatus());
+    }
+
+    private String getPathFromRequest(WebRequest request) {
+        return request.getDescription(false).replace("uri=", "");
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/ErrorLogger.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/ErrorLogger.java
@@ -1,0 +1,28 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.log;
+
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.TypeError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ErrorLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(ErrorLogger.class);
+
+    public static void log(TypeError typeError, String path, Throwable throwable) {
+        LogDetail logDetail = new LogDetail(typeError, path, throwable);
+        if(throwable instanceof Error) {
+            logCriticalError(logDetail);
+        } else {
+            logError(logDetail);
+        }
+    }
+
+    private static void logCriticalError(LogDetail logDetail) {
+        logger.error("ERRO CRÍTICO no servidor: {}", logDetail);
+    }
+
+    private static void logError(LogDetail logDetail) {
+        logger.error("Erro no servidor: {}", logDetail);
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/LogDetail.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/LogDetail.java
@@ -1,0 +1,55 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.log;
+
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.TypeError;
+
+import java.time.LocalDateTime;
+
+public record LogDetail(
+        LocalDateTime timestamp,
+        String errorId,
+        String path,
+        String message,
+        String exception,
+        String cause,
+        String stackTrace
+) {
+
+    private static final String CAUSE_NOT_AVAILABLE = "Causa não disponível";
+
+    public LogDetail(TypeError typeError, String path, Throwable throwable) {
+        this(
+                LocalDateTime.now(),
+                typeError.getErrorId(),
+                path,
+                getMessageOrDefault(throwable, typeError),
+                getExceptionName(throwable),
+                getCauseOrDefault(throwable),
+                getStackTrace(throwable)
+        );
+    }
+
+    private static String getMessageOrDefault(Throwable throwable, TypeError errorType) {
+        return (throwable != null && throwable.getMessage() != null)
+                ? throwable.getMessage()
+                : errorType.getDefaultMessage();
+    }
+
+    private static String getExceptionName(Throwable throwable) {
+        return (throwable != null) ? throwable.getClass().getSimpleName() : null;
+    }
+
+    private static String getCauseOrDefault(Throwable throwable) {
+        return (throwable != null && throwable.getCause() != null)
+                ? throwable.getCause().toString()
+                : CAUSE_NOT_AVAILABLE;
+    }
+
+    private static String getStackTrace(Throwable throwable) {
+        StringBuilder stackTraceBuilder = new StringBuilder();
+        for (StackTraceElement element : throwable.getStackTrace()) {
+            stackTraceBuilder.append(element).append("\n");
+        }
+        return stackTraceBuilder.toString().trim();
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/WarnLogger.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/log/WarnLogger.java
@@ -1,0 +1,16 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.log;
+
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response.TypeError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WarnLogger {
+
+    private static final Logger logger = LoggerFactory.getLogger(WarnLogger.class);
+
+    public static void log(TypeError typeError, String path, Throwable throwable) {
+        LogDetail logDetail = new LogDetail(typeError, path, throwable);
+        logger.warn("Aviso na requisição: {}", logDetail);
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/ResponseError.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/ResponseError.java
@@ -1,0 +1,28 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ResponseError(
+        LocalDateTime timestamp,
+        String errorId,
+        String message,
+        String path,
+        List<ValidationError> validationErrors
+) {
+
+    public ResponseError(TypeError typeError, String path, List<ValidationError> validationErrors) {
+        this(
+                LocalDateTime.now(),
+                typeError.getErrorId(),
+                typeError.getDefaultMessage(),
+                path,
+                validationErrors
+        );
+    }
+
+    public ResponseError(TypeError errorType, String path) {
+        this(errorType, path, null);
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/TypeError.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/TypeError.java
@@ -1,0 +1,33 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum TypeError {
+        BAD_REQUEST("bad_request", HttpStatus.BAD_REQUEST, "A solicitação está inválida."),
+        NOT_FOUND("not_found", HttpStatus.NOT_FOUND, "O recurso solicitado não foi encontrado."),
+        INTERNAL_SERVER_ERROR("internal_server_error", HttpStatus.INTERNAL_SERVER_ERROR, "Erro interno do servidor."),
+        UNAUTHORIZED("unauthorized", HttpStatus.UNAUTHORIZED, "Acesso não autorizado."),
+        FORBIDDEN("forbidden", HttpStatus.FORBIDDEN, "Permissão negada.");
+
+        private final String errorId;
+        private final HttpStatus httpStatus;
+        private final String defaultMessage;
+
+        TypeError(String errorId, HttpStatus httpStatus, String defaultMessage) {
+            this.errorId = errorId;
+            this.httpStatus = httpStatus;
+            this.defaultMessage = defaultMessage;
+        }
+
+    public static TypeError fromStatusCode(HttpStatus httpStatus) {
+        for (TypeError type : TypeError.values()) {
+            if (type.getHttpStatus() == httpStatus) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Tipo de erro não encontrado para o código de status: " + httpStatus);
+    }
+
+}

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/ValidationError.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/infra/exception/response/ValidationError.java
@@ -1,0 +1,8 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.infra.exception.response;
+
+public record ValidationError(
+        String field,
+        String message
+) {
+
+}


### PR DESCRIPTION
- Implementação do tratamento de respostas de erro centralizado, foi deifinida resposta padrão de erro com mensagens mais amigáveis e para os detalhes de erro foi feita uma estrutura de criaçào de logs de acordo com o tipo de logo.
- Foram definidos dois tipos de log Warn e Error, sendo que o log do tipo Error pode ser crítico ou não.
- Erros críticos referem-se a captura de erros mesmo, classes do tipo Error, que geralmente indicam problemas que o programa não consegue recuperar ou tratar, como falhas graves de sistema ou recursos críticos indisponíveis. 
- Investi bastante tempo nesse tratamento para que possamos ter mais detalhes para identificar erros como o que foi relatado no ticket.
- A melhoria no tratamento e lançamento das exceções no restante da API não foi feito aqui, resolvi abordar essas outras partes nas outras tarefas referentes a melhorias específicas em cada tipo de classe.