### PR TITLE
Issue #12 - Rever uso da anotação Transactional

### DIFF
--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/arquivo/ArquivoService.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/arquivo/ArquivoService.java
@@ -2,7 +2,6 @@ package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.arquivo;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.stereotype.Component;
@@ -16,7 +15,6 @@ public class ArquivoService {
     private final ArquivoJpaRepository arquivoRepository;
     private final ObjectMapper objectMapper;
 
-    @Transactional
     public List<ArquivoDTO> listarTodosArquivos() {
         return arquivoRepository.findAll().stream().map(arquivo -> toDTO(arquivo, false)).toList();
     }

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioService.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioService.java
@@ -1,7 +1,6 @@
 package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario;
 
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,12 +20,10 @@ public class UsuarioService {
         this.usuarioMapper = usuarioMapper;
     }
 
-    @Transactional
     public UsuarioResponse detalharUsuario(Long idUsuario) {
         return usuarioMapper.toResponse(buscarUsuario(idUsuario));
     }
 
-    @Transactional
     public UsuarioSimplificadoResponse detalharUsuarioSimplificado(Long idUsuario) {
         return usuarioMapper.toResponseSimplificada(buscarUsuario(idUsuario));
     }


### PR DESCRIPTION
Essa anotação foi retirada das classes de serviço por não serem necessários em métodos e consulta que são Type Safe, ou seja não alteram o estado da aplicação.