### PR TITLE
Issue #26 - Otimizar busca simplificada

### DIFF
--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuario.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuario.java
@@ -11,6 +11,9 @@ public class DetalharUsuario {
     UsuarioRepository usuarioRepository;
 
     public UsuarioResponse execute(Long idUsuario) {
+        if (idUsuario == null) {
+            throw new IllegalArgumentException("O ID do usuário não pode ser nulo");
+        }
         Usuario usuario = usuarioRepository.detalharUsuario(idUsuario);
         return new UsuarioResponse(
                 usuario.getNome(),

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuarioSimplificado.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuarioSimplificado.java
@@ -11,6 +11,9 @@ public class DetalharUsuarioSimplificado {
     UsuarioRepository usuarioRepository;
 
     public UsuarioSimplificadoResponse execute(Long idUsuario) {
+        if (idUsuario == null) {
+            throw new IllegalArgumentException("O ID do usuário não pode ser nulo");
+        }
         Usuario usuario = usuarioRepository.detalharUsuarioSimplificado(idUsuario);
         return new UsuarioSimplificadoResponse(
                 usuario.getNome(),

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioJpaRepository.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioJpaRepository.java
@@ -1,9 +1,16 @@
 package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UsuarioJpaRepository extends JpaRepository<UsuarioEntity, Long> {
+
+    @Query("SELECT u.nome AS nome, u.email AS email FROM UsuarioEntity u WHERE u.id = :idUsuario")
+    Optional<UsuarioSimplificadoProjection> findUsuarioSimplificadoById(@Param("idUsuario") Long idUsuario);
 
 }

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioService.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioService.java
@@ -15,13 +15,25 @@ public class UsuarioService implements UsuarioRepository{
     UsuarioJpaRepository usuarioRepository;
 
     public Usuario detalharUsuario(Long idUsuario) {
-        UsuarioEntity usuarioEntity = buscarUsuario(idUsuario);
-        return restaurar(usuarioEntity);
+        try {
+            UsuarioEntity usuarioEntity = buscarUsuario(idUsuario);
+            return restaurar(usuarioEntity);
+        } catch (EntityNotFoundException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            throw new RuntimeException("Erro inesperado", exception);
+        }
     }
 
     public Usuario detalharUsuarioSimplificado(Long idUsuario) {
-        UsuarioEntity usuarioEntity = buscarUsuario(idUsuario);
-        return Usuario.restaurarSimplificado(usuarioEntity.getNome(), usuarioEntity.getEmail());
+        try {
+            UsuarioSimplificadoProjection usuarioSimplificado= buscarUsuarioSimplificado(idUsuario);
+            return Usuario.restaurarSimplificado(usuarioSimplificado.getNome(), usuarioSimplificado.getEmail());
+        } catch (EntityNotFoundException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            throw new RuntimeException("Erro inesperado", exception);
+        }
     }
 
     public List<Usuario> listarUsuarios(Pageable paginacao) {
@@ -34,7 +46,7 @@ public class UsuarioService implements UsuarioRepository{
         } catch (EntityNotFoundException exception) {
             throw exception;
         } catch (Exception exception) {
-            throw new RuntimeException(exception);
+            throw new RuntimeException("Erro inesperado", exception);
         }
     }
 
@@ -49,14 +61,13 @@ public class UsuarioService implements UsuarioRepository{
     }
 
     private UsuarioEntity buscarUsuario(Long idUsuario) {
-        try {
-            return usuarioRepository.findById(idUsuario)
-                    .orElseThrow(() -> new EntityNotFoundException("Usuário de id " + idUsuario + "não encontrado"));
-        } catch (EntityNotFoundException exception) {
-            throw exception;
-        } catch (Exception exception) {
-            throw new RuntimeException(exception);
-        }
+        return usuarioRepository.findById(idUsuario)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário de id " + idUsuario + "não encontrado"));
+    }
+
+    private UsuarioSimplificadoProjection buscarUsuarioSimplificado(Long idUsuario) {
+        return usuarioRepository.findUsuarioSimplificadoById(idUsuario)
+                .orElseThrow(() -> new EntityNotFoundException("Usuário de id " + idUsuario + " não encontrado"));
     }
 
 }

--- a/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioSimplificadoProjection.java
+++ b/src/main/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioSimplificadoProjection.java
@@ -1,0 +1,7 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario;
+
+public interface UsuarioSimplificadoProjection {
+    String getNome();
+    String getEmail();
+}
+

--- a/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuarioSimplificadoTest.java
+++ b/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usecases/DetalharUsuarioSimplificadoTest.java
@@ -1,0 +1,66 @@
+package br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usecases;
+
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario.Usuario;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario.UsuarioRepository;
+import br.com.sicredi.canaisdigitais.avaliacaotecnicacanais.api.usuario.UsuarioSimplificadoResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DetalharUsuarioSimplificadoTest {
+
+    @Mock
+    UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    DetalharUsuarioSimplificado detalharUsuarioSimplificado;
+
+    @Test
+    void deveRetornarUsuarioSimplificadoQuandoUsuarioExiste() {
+        Long idUsuario = 1L;
+        Usuario usuarioMock = Usuario.restaurarSimplificado("João Silva", "joao.silva@example.com");
+        when(usuarioRepository.detalharUsuarioSimplificado(idUsuario)).thenReturn(usuarioMock);
+        UsuarioSimplificadoResponse response = detalharUsuarioSimplificado.execute(idUsuario);
+        assertEquals("João Silva", response.nome());
+        assertEquals("joao.silva@example.com", response.email());
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoUsuarioNaoExiste() {
+        Long idUsuario = 999L;
+        when(usuarioRepository.detalharUsuarioSimplificado(idUsuario))
+                .thenThrow(new EntityNotFoundException("Usuário não encontrado"));
+        assertThrows(EntityNotFoundException.class, () -> detalharUsuarioSimplificado.execute(idUsuario));
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoIdUsuarioNulo() {
+        assertThrows(IllegalArgumentException.class, () -> detalharUsuarioSimplificado.execute(null));
+    }
+
+    @Test
+    void deveChamarRepositorioComIdCorreto() {
+        Long idUsuario = 1L;
+        Usuario usuarioMock = Usuario.restaurarSimplificado("João Silva", "joao.silva@example.com");
+        when(usuarioRepository.detalharUsuarioSimplificado(idUsuario)).thenReturn(usuarioMock);
+        detalharUsuarioSimplificado.execute(idUsuario);
+        verify(usuarioRepository, times(1)).detalharUsuarioSimplificado(idUsuario);
+    }
+
+    @Test
+    void deveRetornarExcecaoLancadaPeloRepositorio() {
+        Long idUsuario = 2L;
+        when(usuarioRepository.detalharUsuarioSimplificado(idUsuario)).thenThrow(new IllegalArgumentException(
+               "O parâmetro nome não pode ser nulo, vazio ou estar em branco"
+        ));
+        assertThrows(IllegalArgumentException.class, () -> detalharUsuarioSimplificado.execute(idUsuario));
+    }
+
+}

--- a/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioControllerTestIT.java
+++ b/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioControllerTestIT.java
@@ -148,7 +148,7 @@ class UsuarioControllerTestIT extends BaseDatabaseTestContainer {
     }
 
     @Test
-    void erroBaseInconsistenteColunaRemovida() {
+    void erroBaseInconsistenteColunaRemovidaAoListarUsuarios() {
         jdbcTemplate.execute("ALTER TABLE USUARIO DROP COLUMN nome");
         Response response = given()
                 .contentType(ContentType.JSON)
@@ -162,5 +162,24 @@ class UsuarioControllerTestIT extends BaseDatabaseTestContainer {
         response.prettyPrint();
         resetDatabase(jdbcTemplate);
     }
+
+    @Test
+    void erroBaseInconsisteTabelaNaoEncontradaAoDetalharUsuario() {
+        jdbcTemplate.execute("ALTER TABLE USUARIO DROP COLUMN nome");
+        Response response = given()
+                .contentType(ContentType.JSON)
+                .pathParam("idUsuario", 5)
+                .when()
+                .get(pathVersion + "/{idUsuario}")
+                .then()
+                .statusCode(500)
+                .body("status", is(HttpStatusCustom.INTERNAL_SERVER_ERROR.name()))
+                .body("message", is("Erro interno no servidor"))
+                .extract().response();
+        response.prettyPrint();
+        resetDatabase(jdbcTemplate);
+    }
+
+
 
 }

--- a/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioServiceTest.java
+++ b/src/test/java/br/com/sicredi/canaisdigitais/avaliacaotecnicacanais/api/usuario/UsuarioServiceTest.java
@@ -25,7 +25,7 @@ class UsuarioServiceTest {
     UsuarioJpaRepository usuarioRepository;
 
     @Test
-    void retornarUsuarioResponseQuandoDetalharUsuario() {
+    void retornarUsuarioQuandoDetalharUsuario() {
         UsuarioEntity usuarioEntityMock = new UsuarioEntity();
         usuarioEntityMock.setId(1);
         usuarioEntityMock.setNome("João Silva");
@@ -41,7 +41,20 @@ class UsuarioServiceTest {
     }
 
     @Test
-    void runtimeExceptionQuandoRepositorioFalhar() {
+    void retornarUsuarioSimplificadoQuandoDetalharUsuario() {
+        UsuarioSimplificadoProjection usuarioSimplificadoMock = mock(UsuarioSimplificadoProjection.class);
+        when(usuarioSimplificadoMock.getNome()).thenReturn("João Silva");
+        when(usuarioSimplificadoMock.getEmail()).thenReturn("joao.silva@example.com");
+        when(usuarioRepository.findUsuarioSimplificadoById(1L)).thenReturn(Optional.of(usuarioSimplificadoMock));
+        Usuario result = usuarioService.detalharUsuarioSimplificado(1L);
+        assertNotNull(result, "O resultado não deveria ser nulo.");
+        assertEquals("João Silva", result.getNome(), "O nome retornado não é o esperado.");
+        assertEquals("joao.silva@example.com", result.getEmail(), "O e-mail retornado não é o esperado.");
+        verify(usuarioRepository, times(1)).findUsuarioSimplificadoById(1L);
+    }
+
+    @Test
+    void runtimeExceptionQuandoRepositorioFalharAoBuscarListaDeUsuarios() {
         Pageable paginacao = Pageable.ofSize(10);
         when(usuarioRepository.findAll(paginacao)).thenThrow(new IllegalStateException("Erro de banco de dados"));
         RuntimeException thrownException = assertThrows(RuntimeException.class, () -> {


### PR DESCRIPTION
- Criada busca específica para o detalhamento simplificado de usuário, agora ela traz somente os campos nome e email do database USUARIO e os coloca numa projection.
- Durante a realização dos testes no usecase DetalharUsuarioSimplificado percebi que seria necessário validação do parâmetro de entrada, então implementei isso também;